### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = git@github.com:davedelong/SyzygyGlyphish.git
 [submodule "DifferenceKit"]
 	path = DifferenceKit
-	url = git@github.com:ra1028/DifferenceKit.git
+	url = https://github.com/ra1028/DifferenceKit.git


### PR DESCRIPTION
1) I was not able to locate git@github.com:ra1028/DifferenceKit.git. What I propose seems to work, but may not be what you want.

2) I am guessing that "SyzygyGlyphish" may have been renamed "Glyphish", but Syzygy/Glyphish/Sources comes up 404. I made no modifications here.